### PR TITLE
Remove group name configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,19 @@ Available variables are listed below, along with default values.
 
     docker_swarm_network_interface: eth0
     docker_swarm_port: 2377
+    docker_swarm_manager: false
 
-A dedicated master node is used to form the cluster. This node is called primary 
-master and can be set with the `docker_swarm_primary_master_name` variable. The 
-name must match the ansible inventory node name. As default the first member of 
-the current play hosts is taken.
+The first host of the inventory is always used as master node. If another host
+should be used to form the cluster, set `docker_swarm_primary_master_name` to
+the inventory name of one of the hosts. 
 
-    docker_swarm_primary_manager_name: "{{ ansible_play_hosts | first }}"
-    
-All other hosts in the scope of the play, will be configured as worker. If you 
-wish to exclude a host out of the docker swarm, make sure the scope of the play 
-is limited to those hosts.
+WARNING! The first host is ALWAYS configured as master, nontheless the value of
+`docker_swarm_manager` for the first host.
+
+All other hosts will join the cluster as worker nodes. Set
+`docker_swarm_manager` to true for each host that should be confiugred as
+manager.If you wish to exclude a host out of the docker swarm, make sure the
+scope of the play is limited to those hosts.
 
     # playbook.yml example
     ---

--- a/README.md
+++ b/README.md
@@ -29,7 +29,22 @@ Available variables are listed below, along with default values.
     docker_swarm_network_interface: eth0
     docker_swarm_port: 2377
 
-A dedicated master node is used to form the cluster. This node is called primary master and can be set with the `docker_swarm_primary_master_name` variable. The name must match the ansible inventory node name. As default the first member of the current play hosts is taken.
+A dedicated master node is used to form the cluster. This node is called primary 
+master and can be set with the `docker_swarm_primary_master_name` variable. The 
+name must match the ansible inventory node name. As default the first member of 
+the current play hosts is taken.
+
+    docker_swarm_primary_manager_name: "{{ ansible_play_hosts | first }}"
+    
+All other hosts in the scope of the play, will be configured as worker. If you 
+wish to exclude a host out of the docker swarm, make sure the scope of the play 
+is limited to those hosts.
+
+    # playbook.yml example
+    ---
+    - hosts: swarmMembers
+      roles:
+        - role: fgierlinger.docker_swarm
 
 Usage
 -----

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,7 @@ docker_swarm_network_interface: eth0
 
 # Port docker swarm will communicate on
 docker_swarm_port: 2377
+
+# set to true on each host that should be a master, or 
+# globally if all hosts should join the swarm as master
+docker_swarm_manager: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,6 +34,7 @@
   when:
     - not _swarm_info.docker_swarm_active
     - inventory_hostname != docker_swarm_primary_manager_name
+    - not docker_swarm_manager
 
 - name: Join swarm as manager
   docker_swarm:
@@ -43,4 +44,4 @@
     remote_addrs: "{{ hostvars[docker_swarm_primary_manager_name].docker_swarm_addr }}"
   when:
     - not _swarm_info.docker_swarm_manager
-    - inventory_hostname != docker_swarm_primary_manager_name
+    - docker_swarm_manager

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,7 +33,7 @@
     remote_addrs: "{{ hostvars[docker_swarm_primary_manager_name].docker_swarm_addr }}"
   when:
     - not _swarm_info.docker_swarm_active
-    - "'docker_swarm_worker' in group_names"
+    - inventory_hostname != docker_swarm_primary_manager_name
 
 - name: Join swarm as manager
   docker_swarm:
@@ -43,5 +43,4 @@
     remote_addrs: "{{ hostvars[docker_swarm_primary_manager_name].docker_swarm_addr }}"
   when:
     - not _swarm_info.docker_swarm_manager
-    - "'docker_swarm_manager' in group_names"
-    - not inventory_hostname == docker_swarm_primary_manager_name
+    - inventory_hostname != docker_swarm_primary_manager_name


### PR DESCRIPTION
All members in the scope of the play will be part of the cluster. No more group membership needed.