### PR TITLE
stick to ansible-lint < 5.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
   molecule:
     name: Molecule
     runs-on: ubuntu-latest
+    needs: lint
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install ansible ansible-lint<5.0.0 yamllint
+        run: pip3 install "ansible" "ansible-lint<5.0.0" "yamllint"
 
       - name: Lint code.
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install ansible ansible-lint!=5.0.0 yamllint
+        run: pip3 install ansible ansible-lint<5.0.0 yamllint
 
       - name: Lint code.
         run: |


### PR DESCRIPTION
The file `molecule/default/requirements.yml` is mistaken as a playbook. Therefore `ansible-lint` fails during the pipeline.

```
yntax-check: 'src' is not a valid attribute for a Play
molecule/default/requirements.yml:2:3 [WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that
the implicit localhost does not match 'all'
ERROR! 'src' is not a valid attribute for a Play

The error appears to be in '/fgierlinger.docker_swarm/molecule/default/requirements.yml': line 2, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

---
- src: geerlingguy.docker
  ^ here
```

Since there seem to be multiple issues with CI and the new ansible-lint 5.0.0 release, the CI pipeline will use versions smaller than 5.0.0.

 
Related ansible-community/ansible-lint#1369